### PR TITLE
doHydrateRowData(): go through the chain of parent classes to find the property

### DIFF
--- a/Hydrator/SimpleObjectHydrator.php
+++ b/Hydrator/SimpleObjectHydrator.php
@@ -103,7 +103,17 @@ class SimpleObjectHydrator extends ArrayHydrator
                    continue;
                }
             } else {
-                $property = $reflection->getProperty($name);
+                for (;;) {
+                    try {
+                        $property = $reflection->getProperty($name);
+                        break;
+                    } catch (\ReflectionException $e) {}
+
+                    $reflection = $reflection->getParentClass();
+                    if ($reflection === false) {
+                        throw new \Exception("Can't find attribute '$name' in $className");
+                    }
+                }
             }
 
             if ($property->isPublic()) {


### PR DESCRIPTION
Private properties can only be found on the class itself, not its subclasses.
And doctrine-read-only-hydrator uses a proxy subclass for every entity.